### PR TITLE
Fix duplicating field for singular field

### DIFF
--- a/includes/fields/cmb.php
+++ b/includes/fields/cmb.php
@@ -33,6 +33,19 @@ class Icon_Picker_Field_Cmb extends CMB_Field {
 	}
 
 	/**
+	 * Get multiple values for a field.
+	 *
+	 * We need to wrap this for HTML CMB display
+	 *
+	 * @return array
+	 */
+	public function &get_values() {
+		if ( count( $this->values ) !== 1 ) {
+			return array( $this->values );
+		}
+	}
+
+	/**
 	 * Display the field
 	 *
 	 * @since 0.1.0


### PR DESCRIPTION
![slice1](https://cloud.githubusercontent.com/assets/1890984/24296734/41821a0e-1098-11e7-8895-c45c7bff6118.png)

When used as a single items the fields are being duplicated as the data format for this is an array with the `type` and `icon` keys, this when CMB calls `display()` when the field is displayed it loops through the singular field set so each key is classed as a value resulting in`type` and `icon` each being treated as there own fields. Wrapping this value in an array fixes the display.

