### PR TITLE
Version bump to 0.5.1 to burst cache

### DIFF
--- a/icon-picker.php
+++ b/icon-picker.php
@@ -21,7 +21,7 @@
 
 final class Icon_Picker {
 
-	const VERSION = '0.5.0';
+	const VERSION = '0.5.1';
 
 	/**
 	 * Icon_Picker singleton


### PR DESCRIPTION
After JS changes in #5 the browsers need to be forced to flush the cached files.